### PR TITLE
Update Sonartype publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,12 @@ plugins {
     id 'groovy'
     id 'maven-publish'
     id 'signing'
-    id 'nebula.release' version '15.2.0'
+    id 'nebula.release' version '15.3.1'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.8.2'
-    id 'io.codearte.nexus-staging' version '0.22.0'
-    id "de.marcphilipp.nexus-publish" version "0.4.0"
+    id 'com.github.kt3k.coveralls' version '2.12.0'
+    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
+
 
 group "com.wooga.xcodebuild"
 
@@ -48,15 +48,10 @@ repositories {
     mavenCentral()
 }
 
-task sourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-
-javadoc.failOnError = false
-task javadocJar(type: Jar) {
-    archiveClassifier.set('javadoc')
-    from javadoc
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    withJavadocJar()
+    withSourcesJar()
 }
 
 jacocoTestReport {
@@ -66,22 +61,11 @@ jacocoTestReport {
     }
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
-
 publishing {
     publications {
         main(MavenPublication) {
-            artifactId = project.name
             from(components["java"])
-            artifact sourcesJar {
-                classifier "sources"
-            }
-            artifact javadocJar {
-                classifier "javadoc"
-            }
+
             pom {
                 name = 'xcpretty'
                 description = 'A fast and flexible formatter for xcodebuild.'
@@ -117,14 +101,11 @@ publishing {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype {
+            username = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
+            password = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
+        }
     }
-}
-
-nexusStaging {
-    username = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
-    password = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
-    packageGroup = "com.wooga"
 }
 
 signing {
@@ -136,7 +117,11 @@ signing {
 }
 
 postRelease.dependsOn(tasks.publish)
-tasks."final".dependsOn(tasks.closeAndReleaseRepository)
-tasks."candidate".dependsOn(tasks.closeAndReleaseRepository)
-tasks.closeAndReleaseRepository.mustRunAfter(tasks.postRelease)
-tasks.publish.mustRunAfter(tasks.release)
+
+afterEvaluate {
+    tasks."final".dependsOn(tasks.publishToSonatype, tasks.closeAndReleaseSonatypeStagingRepository)
+    tasks."candidate".dependsOn(tasks.publishToSonatype, tasks.closeAndReleaseSonatypeStagingRepository)
+    tasks.publishToSonatype.mustRunAfter(tasks.postRelease)
+    tasks.closeSonatypeStagingRepository.mustRunAfter(tasks.publishToSonatype)
+    tasks.publish.mustRunAfter(tasks.release)
+}


### PR DESCRIPTION
## Description

The plugin used for sonartype OSSHR publish is no longer maintained. This patch replaces this with a new plugin. I also adjusted some java settings so we have no longer the need to declare the sources and doc jar as seperate tasks.

## Changes

* ![UPDATE] sonartype OSSHR publish plugin to `io.github.gradle-nexus.publish-plugin`
* ![IMPROVE] java build setup

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"